### PR TITLE
Redirect to Titan Tv by exiting out of the application

### DIFF
--- a/lib/hive/worker/tv.rb
+++ b/lib/hive/worker/tv.rb
@@ -246,7 +246,6 @@ require(
         TVAPI.application  = Application.getCurrentApplication();
         TVAPI.device       = TVAPI.application.getDevice();
 
-
         TVAPI.isAppReady = function() {
           var container = TVAPI.application.getRootWidget();
           return !!container;
@@ -255,12 +254,6 @@ require(
         TVAPI.reload = function() {
           window.location.reload();
         };
-
-        TVAPI.hashLoad = function(hash) {
-          window.location.hash = hash
-          window.location.reload(true);
-        };
-
 
         TVAPI.exitApp = function() {
           return TVAPI.application.exit();
@@ -271,7 +264,7 @@ JS
                ts.execute("TVAPI.exitApp();")
                @log.info("Exit SUCCESS")
              rescue
-               sleep 20
+               sleep 15
                current_app = @hive_mind.device_details(refresh: true)['application']
                @log.info("In rescue. Current App: #{current_app}")
                if current_app == Hive.config.network.tv.titantv_name

--- a/lib/hive/worker/tv.rb
+++ b/lib/hive/worker/tv.rb
@@ -290,5 +290,6 @@ JS
         end
 
       end
+    end
   end
 end

--- a/lib/hive/worker/tv.rb
+++ b/lib/hive/worker/tv.rb
@@ -228,7 +228,7 @@ JS
         @log.info("Current App: #{current_app}")
         @log.info("Opts URL: #{opts[:url]}")
         if opts[:url] == Hive.config.network.tv.titantv_url && opts[:url] != current_app && current_app != Hive.config.network.tv.titantv_name
-           @log.info("Redirecting to TitanTV app by exiting TVAPI")
+           @log.info("Redirecting to TitanTV by exiting application")
            ts = Talkshow.new
            ts.start_server(port: @ts_port, logfile: "#{@file_system.results_path}/talkshowserver.log")
              begin
@@ -246,15 +246,6 @@ require(
         TVAPI.application  = Application.getCurrentApplication();
         TVAPI.device       = TVAPI.application.getDevice();
 
-        TVAPI.isAppReady = function() {
-          var container = TVAPI.application.getRootWidget();
-          return !!container;
-        };
-
-        TVAPI.reload = function() {
-          window.location.reload();
-        };
-
         TVAPI.exitApp = function() {
           return TVAPI.application.exit();
         };
@@ -262,24 +253,22 @@ require(
 );
 JS
                ts.execute("TVAPI.exitApp();")
-               @log.info("Exit SUCCESS")
+               @log.info("Exited out of the application")
              rescue
                sleep 15
                current_app = @hive_mind.device_details(refresh: true)['application']
-               @log.info("In rescue. Current App: #{current_app}")
                if current_app == Hive.config.network.tv.titantv_name
-                 @log.info("Exited out of the app successfully ")
+                 @log.info("Exited out of the application successfully")
                else
                  @log.info("Forced redirect unsuccessful")
                end
              end
              current_app = @hive_mind.device_details(refresh: true)['application']
-             @log.info(current_app)
-             @log.info("Stopping Server")
+             @log.info("Current App: #{current_app}")
              ts.stop_server
              load_hive_mind(@ts_port, opts[:url]) if ! opts[:skip_last_load]
         else
-           @log.info("Already on Titan TV")
+           @log.info("Already on Titan TV. Skipped forced redirect.")
         end
 
       end

--- a/lib/hive/worker/tv.rb
+++ b/lib/hive/worker/tv.rb
@@ -260,7 +260,7 @@ JS
                if current_app == Hive.config.network.tv.titantv_name
                  @log.info("Exited out of the application successfully")
                else
-                 @log.info("Forced redirect unsuccessful")
+                 @log.error("Forced redirect unsuccessful")
                end
              end
              current_app = @hive_mind.device_details(refresh: true)['application']


### PR DESCRIPTION
Few of the times hive_mind_api is not able to redirect TV's to holding application (TitanTV app). In this scenario using forced_direct we inject TVAPI js for exit and exit out of the application forcefully.