### PR TITLE
Repair: redirect to holding application

### DIFF
--- a/lib/hive/worker/tv.rb
+++ b/lib/hive/worker/tv.rb
@@ -186,6 +186,7 @@ module Hive
       # Between tests the TV must be in the holding app
       def diagnostics
         app_name = @hive_mind.device_details(refresh: true)['application']
+        @log.error("Repairing: TV is not on holding app")
         if app_name != Hive.config.network.tv.titantv_name
           raise DeviceNotReady.new("Current application: '#{app_name}'") if repair != Hive.config.network.tv.titantv_name
         end


### PR DESCRIPTION
Observed that few of the times hive fails to redirect tv to holding application. This is a diagnostic check if the TV is on holding application and try to redirect when not on holding app.

It also includes killing anything running on ts_port before starting the talkshow server. We need to do this because many times either due to test or hive not clearing the ports properly and these residue process running on ts_port block talkshow in giving efficient output.